### PR TITLE
Update of testFile.sh

### DIFF
--- a/bin/testFile.sh
+++ b/bin/testFile.sh
@@ -2,8 +2,11 @@
 
 # echo Testing $1
 
-. ~/cmsShow-7.1/external/root/bin/thisroot.sh 
-LD_LIBRARY_PATH=:$LD_LIBRARY_PATH:/home/vis/cmsShow-7.1/external/lib
+#. ~/cmsShow-8.1/external/root/bin/thisroot.sh 
+#LD_LIBRARY_PATH=:$LD_LIBRARY_PATH:/home/vis/cmsShow-8.1/external/lib
+
+export SHELLDIR=/home/vis/cmsShowLast
+. $SHELLDIR/env.sh
 
 # root.exe <<EOF
 root.exe > /dev/null 2>&1 <<EOF
@@ -20,6 +23,16 @@ printf("Foo %lld\n", fp);
 }
 else
 {
+  TTree *t = (TTree*)fp->Get("Events");
+  if (t == 0) {
+    printf("Tree %lld\n", t);
+    gSystem->Exit(1);
+  }
+  if (t->GetEntries() == 0) {
+    printf("No events\n");
+    gSystem->Exit(1);
+  }
+
   gSystem->Exit(0);
 }
 }


### PR DESCRIPTION
This PR, aimed at P5, includes both a loading of root via the latest cmsShow release (symlinked to /home/vis/cmsShowLast), and a check that the file contains >0 entries.
The latter change was already in use at P5 before 2018.